### PR TITLE
Credit each emoji's author + a contributors highlight

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,10 +73,13 @@ and someone (possibly a passing Claude) may build it.
 
 - Emoji are read at 32 px in Slack — favour **bold shapes over fine detail**,
   and test what your GIF looks like small.
-- **Draw Clawd big.** Default to spanning the full canvas width — `SCALE=10`
-  is a 120 px sprite, leaving exactly the 4 px his outline needs — and only go
-  smaller to make room for props or motion. Whatever you do, **never crop**:
-  no frame may push a pixel (outline included) past the canvas edge.
+- **Fill the frame — no padding.** Scale Clawd as large as the canvas allows:
+  `SCALE=10` is a 120 px sprite spanning the full width, leaving exactly the
+  4 px his outline needs. Shrink him only when something earns the space —
+  props, motion range, or a full-frame scene (a meadow, a breaking wave) that
+  itself reaches the edges. Empty margin around the whole composition is a
+  bug, not a style. Whatever you do, **never crop**: no frame may push a
+  pixel (outline included) past the canvas edge.
 - Prefer the **full 128 grid** (`CELL=1`) for anything with curves or
   rotation; it halves the chunkiness.
 - Keep tunables as named constants near the top with a comment — every

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,8 +85,9 @@ and someone (possibly a passing Claude) may build it.
 
 ## Credit
 
-Your `meta.json` `author` shows up with your emoji. Add yourself — that's the
-fun part.
+Your `meta.json` `author` shows up under your emoji in the README table and on
+the gallery site, and your GitHub avatar joins the contributors strip in the
+README. Add yourself — that's the fun part.
 
 ## Licence note
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,13 @@ logo. No image editor involved.
 | **Original Clawdster** | **This is Clawd** 🔥 | **London Clawd** 🌧️ | **Clawd Surfing** 🏄 |
 |:---:|:---:|:---:|:---:|
 | ![base](emoji/base/clawd_emoji.png) | ![fire](emoji/fire/clawd_fire.gif) | ![rain](emoji/rain/clawd_rain.gif) | ![surf](emoji/surf/clawd_surf.gif) |
+| <sub>by Clawd himself 🦀</sub> | <sub>by Clawd himself 🦀</sub> | <sub>by Clawd himself 🦀</sub> | <sub>by Clawd himself 🦀</sub> |
 | **Mariachlawd** 🪇 | **Bug Claught** 🦋 | **Clawdin Hood** 🏹 | **Clawd Life** 😎 |
 | ![mariachi](emoji/mariachi/clawd_mariachi.gif) | ![bugcatcher](emoji/bugcatcher/clawd_bugcatcher.gif) | ![robinhood](emoji/robinhood/clawd_robinhood.gif) | ![dealwithit](emoji/dealwithit/clawd_dealwithit.gif) |
+| <sub>by Clawd himself 🦀</sub> | <sub>by Clawd himself 🦀</sub> | <sub>by Clawd himself 🦀</sub> | <sub>by Clawd himself 🦀</sub> |
 | **Definitely Not Clawd** 🥸 |  |  |  |
 | ![notclawd](emoji/notclawd/clawd_notclawd.gif) |  |  |  |
+| <sub>by Clawd himself 🦀</sub> |  |  |  |
 <!-- gallery:end -->
 
 Browse the **[live gallery](https://afspies.github.io/ClawdMoji/)** (GIFs
@@ -261,6 +264,16 @@ New Clawd variants are very welcome — a variant is just one folder with one
 [`emoji/_template/`](emoji/_template/). Not a coder? Open an
 [emoji idea](https://github.com/afspies/ClawdMoji/issues/new?template=emoji-idea.yml)
 instead.
+
+### Contributors
+
+Every variant is credited to its `meta.json` author, under the emoji and here
+(generated like everything else — your avatar appears when your first Clawd
+lands):
+
+<!-- contributors:begin -->
+<a href="https://afspies.github.io/ClawdMoji/"><img src="emoji/base/clawd_emoji.png" width="64" height="64" alt="Clawd himself" title="Clawd himself"></a>
+<!-- contributors:end -->
 
 ## License
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,6 +19,8 @@
   .card img { image-rendering: pixelated; width: 128px; height: 128px; }
   .card h2 { font-size: 1.05rem; margin-top: .6rem; }
   .card p { color: var(--dim); font-size: .8rem; margin: .35rem 0 .7rem; min-height: 3.6em; }
+  .card p.by { font-size: .7rem; margin: .15rem 0 0; min-height: 0; }
+  .card p.by a { color: var(--clawd); text-decoration: none; }
   .name { background: #2c2839; color: var(--clawd); border: 1px solid #3a3550; border-radius: 6px; font: inherit; font-size: .85rem; padding: .25rem .6rem; cursor: pointer; }
   .name.copied::after { content: " ✓"; }
   .dl { display: block; color: var(--dim); font-size: .75rem; margin-top: .5rem; }
@@ -42,6 +44,7 @@
       <div class="card">
         <img src="https://raw.githubusercontent.com/afspies/ClawdMoji/main/emoji/base/clawd_emoji.png" alt="Original Clawdster" width="128" height="128">
         <h2>Original Clawdster</h2>
+        <p class="by">by Clawd himself 🦀</p>
         <p>The recovered 12x8 pixel grid, rendered razor-sharp.</p>
         <button class="name" data-name=":clawd:" title="click to copy">:clawd:</button>
         <a class="dl" href="https://raw.githubusercontent.com/afspies/ClawdMoji/main/emoji/base/clawd_emoji.png" download>download</a>
@@ -49,6 +52,7 @@
       <div class="card">
         <img src="https://raw.githubusercontent.com/afspies/ClawdMoji/main/emoji/fire/clawd_fire.gif" alt="This is Clawd" width="128" height="128">
         <h2>This is Clawd 🔥</h2>
+        <p class="by">by Clawd himself 🦀</p>
         <p>Calm in a burning room — a real Doom-fire simulation.</p>
         <button class="name" data-name=":clawd-fine:" title="click to copy">:clawd-fine:</button>
         <a class="dl" href="https://raw.githubusercontent.com/afspies/ClawdMoji/main/emoji/fire/clawd_fire.gif" download>download</a>
@@ -56,6 +60,7 @@
       <div class="card">
         <img src="https://raw.githubusercontent.com/afspies/ClawdMoji/main/emoji/rain/clawd_rain.gif" alt="London Clawd" width="128" height="128">
         <h2>London Clawd 🌧️</h2>
+        <p class="by">by Clawd himself 🦀</p>
         <p>Under a churning storm cloud, sheared rain and floor splashes.</p>
         <button class="name" data-name=":clawd-rain:" title="click to copy">:clawd-rain:</button>
         <a class="dl" href="https://raw.githubusercontent.com/afspies/ClawdMoji/main/emoji/rain/clawd_rain.gif" download>download</a>
@@ -63,6 +68,7 @@
       <div class="card">
         <img src="https://raw.githubusercontent.com/afspies/ClawdMoji/main/emoji/surf/clawd_surf.gif" alt="Clawd Surfing" width="128" height="128">
         <h2>Clawd Surfing 🏄</h2>
+        <p class="by">by Clawd himself 🦀</p>
         <p>Dropping down the face of a breaking wave, rooster-tail flying.</p>
         <button class="name" data-name=":clawd-surf:" title="click to copy">:clawd-surf:</button>
         <a class="dl" href="https://raw.githubusercontent.com/afspies/ClawdMoji/main/emoji/surf/clawd_surf.gif" download>download</a>
@@ -70,6 +76,7 @@
       <div class="card">
         <img src="https://raw.githubusercontent.com/afspies/ClawdMoji/main/emoji/mariachi/clawd_mariachi.gif" alt="Mariachlawd" width="128" height="128">
         <h2>Mariachlawd 🪇</h2>
+        <p class="by">by Clawd himself 🦀</p>
         <p>Sombrero on, maracas shaking, a little cha-cha step.</p>
         <button class="name" data-name=":clawd-mariachi:" title="click to copy">:clawd-mariachi:</button>
         <a class="dl" href="https://raw.githubusercontent.com/afspies/ClawdMoji/main/emoji/mariachi/clawd_mariachi.gif" download>download</a>
@@ -77,6 +84,7 @@
       <div class="card">
         <img src="https://raw.githubusercontent.com/afspies/ClawdMoji/main/emoji/bugcatcher/clawd_bugcatcher.gif" alt="Bug Claught" width="128" height="128">
         <h2>Bug Claught 🦋</h2>
+        <p class="by">by Clawd himself 🦀</p>
         <p>Net-swinging butterfly chase in a sunny meadow.</p>
         <button class="name" data-name=":clawd-bugcatcher:" title="click to copy">:clawd-bugcatcher:</button>
         <a class="dl" href="https://raw.githubusercontent.com/afspies/ClawdMoji/main/emoji/bugcatcher/clawd_bugcatcher.gif" download>download</a>
@@ -84,6 +92,7 @@
       <div class="card">
         <img src="https://raw.githubusercontent.com/afspies/ClawdMoji/main/emoji/robinhood/clawd_robinhood.gif" alt="Clawdin Hood" width="128" height="128">
         <h2>Clawdin Hood 🏹</h2>
+        <p class="by">by Clawd himself 🦀</p>
         <p>Draws his bow and looses an arrow — over and over.</p>
         <button class="name" data-name=":clawd-robinhood:" title="click to copy">:clawd-robinhood:</button>
         <a class="dl" href="https://raw.githubusercontent.com/afspies/ClawdMoji/main/emoji/robinhood/clawd_robinhood.gif" download>download</a>
@@ -91,6 +100,7 @@
       <div class="card">
         <img src="https://raw.githubusercontent.com/afspies/ClawdMoji/main/emoji/dealwithit/clawd_dealwithit.gif" alt="Clawd Life" width="128" height="128">
         <h2>Clawd Life 😎</h2>
+        <p class="by">by Clawd himself 🦀</p>
         <p>Shades drop, text slams — he deals with it, GTA style.</p>
         <button class="name" data-name=":deal-with-clawd:" title="click to copy">:deal-with-clawd:</button>
         <a class="dl" href="https://raw.githubusercontent.com/afspies/ClawdMoji/main/emoji/dealwithit/clawd_dealwithit.gif" download>download</a>
@@ -98,6 +108,7 @@
       <div class="card">
         <img src="https://raw.githubusercontent.com/afspies/ClawdMoji/main/emoji/notclawd/clawd_notclawd.gif" alt="Definitely Not Clawd" width="128" height="128">
         <h2>Definitely Not Clawd 🥸</h2>
+        <p class="by">by Clawd himself 🦀</p>
         <p>Glasses, nose, moustache — the disguise is impenetrable.</p>
         <button class="name" data-name=":definitely-not-clawd:" title="click to copy">:definitely-not-clawd:</button>
         <a class="dl" href="https://raw.githubusercontent.com/afspies/ClawdMoji/main/emoji/notclawd/clawd_notclawd.gif" download>download</a>

--- a/emoji/_template/render.py
+++ b/emoji/_template/render.py
@@ -15,9 +15,11 @@ House rules (CI enforces the first two):
   * the loop must be seamless: drive motion with sin/cos of 2*pi*f/F so
     frame 0 and frame F match exactly.
   * stay authentic to Clawd — build ON the shared ART grid, don't reshape him.
-  * draw him BIG: default to spanning the full canvas width (SCALE=10 leaves
-    exactly the 4 px his outline needs) and only shrink to make room for
-    props/motion — but never let a single pixel crop at the canvas edge.
+  * fill the frame, no padding: scale Clawd as large as the canvas allows
+    (SCALE=10 spans the full width, leaving exactly the 4 px his outline
+    needs). Shrink him only for props, motion range, or a scene that itself
+    fills the square — dead margin around the composition is a bug. And
+    never let a single pixel crop at the canvas edge.
 """
 import sys
 from pathlib import Path

--- a/tools/gen_gallery.py
+++ b/tools/gen_gallery.py
@@ -11,10 +11,15 @@ Each emoji folder owns a small meta.json:
       "slack": "clawd-robinhood",       # suggested :name:
       "file": "clawd_robinhood.gif",    # the output to show
       "blurb": "one-liner",             # used on the docs site
-      "author": "afspies"               # github handle
+      "author": "afspies"               # github handle — credited under the emoji
     }
 
-so adding a variant never means hand-editing the README table — run
+The author is credited under each emoji (README table + docs cards) and in the
+README contributors strip. The repo owner's credits render as "Clawd himself"
+— self-crediting every card would be obnoxious — and he appears in the strip
+as Clawd's pixel avatar.
+
+So adding a variant never means hand-editing the README table — run
 
     python3 tools/gen_gallery.py          # rewrite README + docs/index.html
     python3 tools/gen_gallery.py --check  # exit 1 if anything is stale (CI)
@@ -28,6 +33,9 @@ REPO = "afspies/ClawdMoji"
 RAW = f"https://raw.githubusercontent.com/{REPO}/main"
 COLS = 4
 BEGIN, END = "<!-- gallery:begin -->", "<!-- gallery:end -->"
+C_BEGIN, C_END = "<!-- contributors:begin -->", "<!-- contributors:end -->"
+OWNER = "afspies"  # the owner's credits render as Clawd himself (see docstring)
+OWNER_CREDIT = "Clawd himself 🦀"
 
 
 def load_metas():
@@ -47,6 +55,12 @@ def label(m):
     return f"**{m['title']}** {m['emoji']}".strip()
 
 
+def credit_md(m):
+    if m["author"] == OWNER:
+        return f"<sub>by {OWNER_CREDIT}</sub>"
+    return f"<sub>by [@{m['author']}](https://github.com/{m['author']})</sub>"
+
+
 def readme_table(metas):
     rows = [metas[i:i + COLS] for i in range(0, len(metas), COLS)]
     lines = []
@@ -62,26 +76,60 @@ def readme_table(metas):
             )
             + " |"
         )
+        lines.append("| " + " | ".join([credit_md(m) for m in row] + pad) + " |")
     return "\n".join(lines)
 
 
-def render_readme(metas, text):
+def contributors_strip(metas):
+    """One avatar per unique author, in gallery order; the owner is Clawd."""
+    seen, cells = set(), []
+    for m in metas:
+        a = m["author"]
+        if a in seen:
+            continue
+        seen.add(a)
+        if a == OWNER:
+            cells.append(
+                '<a href="https://afspies.github.io/ClawdMoji/">'
+                '<img src="emoji/base/clawd_emoji.png" width="64" height="64" '
+                'alt="Clawd himself" title="Clawd himself"></a>'
+            )
+        else:
+            cells.append(
+                f'<a href="https://github.com/{a}">'
+                f'<img src="https://github.com/{a}.png?size=128" width="64" height="64" '
+                f'alt="@{a}" title="@{a}"></a>'
+            )
+    return "\n".join(cells)
+
+
+def splice(text, begin, end, body):
     try:
-        head, rest = text.split(BEGIN, 1)
-        _, tail = rest.split(END, 1)
+        head, rest = text.split(begin, 1)
+        _, tail = rest.split(end, 1)
     except ValueError:
-        sys.exit(f"README.md is missing the {BEGIN} / {END} markers")
-    return head + BEGIN + "\n" + readme_table(metas) + "\n" + END + tail
+        sys.exit(f"README.md is missing the {begin} / {end} markers")
+    return head + begin + "\n" + body + "\n" + end + tail
+
+
+def render_readme(metas, text):
+    text = splice(text, BEGIN, END, readme_table(metas))
+    return splice(text, C_BEGIN, C_END, contributors_strip(metas))
 
 
 def render_docs(metas):
     cards = []
     for m in metas:
         flair = f" {m['emoji']}" if m["emoji"] else ""
+        if m["author"] == OWNER:
+            credit = f"by {OWNER_CREDIT}"
+        else:
+            credit = f'by <a href="https://github.com/{m["author"]}">@{m["author"]}</a>'
         cards.append(f"""\
       <div class="card">
         <img src="{RAW}/emoji/{m['dir']}/{m['file']}" alt="{m['title']}" width="128" height="128">
         <h2>{m['title']}{flair}</h2>
+        <p class="by">{credit}</p>
         <p>{m['blurb']}</p>
         <button class="name" data-name=":{m['slack']}:" title="click to copy">:{m['slack']}:</button>
         <a class="dl" href="{RAW}/emoji/{m['dir']}/{m['file']}" download>download</a>
@@ -108,6 +156,8 @@ def render_docs(metas):
   .card img {{ image-rendering: pixelated; width: 128px; height: 128px; }}
   .card h2 {{ font-size: 1.05rem; margin-top: .6rem; }}
   .card p {{ color: var(--dim); font-size: .8rem; margin: .35rem 0 .7rem; min-height: 3.6em; }}
+  .card p.by {{ font-size: .7rem; margin: .15rem 0 0; min-height: 0; }}
+  .card p.by a {{ color: var(--clawd); text-decoration: none; }}
   .name {{ background: #2c2839; color: var(--clawd); border: 1px solid #3a3550; border-radius: 6px; font: inherit; font-size: .85rem; padding: .25rem .6rem; cursor: pointer; }}
   .name.copied::after {{ content: " ✓"; }}
   .dl {{ display: block; color: var(--dim); font-size: .75rem; margin-top: .5rem; }}


### PR DESCRIPTION
## What

Makes the `meta.json` `author` field actually do something (CONTRIBUTING has promised it would since the generator landed):

- **Per-emoji credit** — the README gallery table gets a `<sub>by @handle</sub>` line under each emoji, and each card on the live gallery site gets a matching "by @handle" line.
- **Contributors strip** — a new generated `### Contributors` block in the README: one linked 64px GitHub avatar per unique author, in gallery order, between `<!-- contributors:begin/end -->` markers (same pattern as the gallery table).

## The Clawd-himself twist

The repo owner self-crediting all nine cards would be obnoxious, so owner-authored emoji render as **"by Clawd himself 🦀"** — which also keeps every table cell filled so spacing stays uniform. In the contributors strip the owner appears as Clawd's pixel avatar (linking to the live gallery), so real contributors' faces join Clawd as their first variant lands.

Everything stays generated — `gen_gallery.py --check` passes, so CI keeps guarding against hand-edits.

## Also

- Rebased onto main to pick up Clawd Life 😎 (#8); the gallery regenerates with all nine emoji credited.
- Sharpened the sizing rule in CONTRIBUTING and the `_template` docstring: **fill the frame, no padding** — scale Clawd as large as the canvas allows, shrinking only for props, motion range, or a scene that itself fills the square.

🤖 Generated with [Claude Code](https://claude.com/claude-code)